### PR TITLE
Dva/fix proxy cached

### DIFF
--- a/proxy_cached/Dockerfile
+++ b/proxy_cached/Dockerfile
@@ -6,6 +6,8 @@ LABEL maintainer="Platforme <development@platforme.com>"
 EXPOSE 80
 EXPOSE 443
 
+ARG APORTS_COMMIT=7843f08683dff0ce67394eb8be2f58f598606199
+
 ENV SERVER_NAME=localhost
 ENV PROXY_PROTO=https://
 ENV PROXY_HOST=app.platforme.com
@@ -17,13 +19,28 @@ COPY varnish.default.template /
 
 RUN set -e; \
     \
-    apk add --no-cache envsubst nginx; \
-    apk add varnish --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main; \
-    apk add varnish-modules --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
+    apk add --no-cache envsubst varnish nginx; \
+    \
+    apk add --virtual build -q --no-progress --update alpine-sdk sudo; \
+    adduser -D builder; \
+    echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder; \
+    addgroup builder abuild; \
+    su builder -c "abuild-keygen -nai"; \
+    git clone https://gitlab.alpinelinux.org/alpine/aports.git; \
+    cd aports; git checkout $APORTS_COMMIT; \
+    cd testing/varnish-modules; \
+    chown builder -R .; \
+    sed -i 's/~=/>=/g' APKBUILD; \
+    su builder -c "abuild -r"; \
+    tree ~builder/packages/; \
+    apk add --allow-untrusted ~builder/packages/testing/**/varnish-modules-0.22.0-r0.apk; \
     \
     rm /etc/nginx/http.d/default.conf; \
     nginx -t -c /etc/nginx/nginx.conf; \
     \
+    apk del --no-network build; \
+    rm -rf ~builder /packages /aports /etc/sudoers.d/builder; \
+    deluser --remove-home builder; \
     chown varnish /var/lib/varnish;
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/proxy_cached/Dockerfile
+++ b/proxy_cached/Dockerfile
@@ -6,8 +6,6 @@ LABEL maintainer="Platforme <development@platforme.com>"
 EXPOSE 80
 EXPOSE 443
 
-ARG APORTS_COMMIT=7843f08683dff0ce67394eb8be2f58f598606199
-
 ENV SERVER_NAME=localhost
 ENV PROXY_PROTO=https://
 ENV PROXY_HOST=app.platforme.com
@@ -19,27 +17,13 @@ COPY varnish.default.template /
 
 RUN set -e; \
     \
-    apk add --no-cache envsubst varnish nginx; \
-    \
-    apk add --virtual build -q --no-progress --update alpine-sdk sudo; \
-    adduser -D builder; \
-    echo "builder ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/builder; \
-    addgroup builder abuild; \
-    su builder -c "abuild-keygen -nai"; \
-    git clone https://gitlab.alpinelinux.org/alpine/aports.git; \
-    cd aports; git checkout $APORTS_COMMIT; \
-    cd testing/varnish-modules; \
-    chown builder -R .; \
-    su builder -c "abuild -r"; \
-    tree ~builder/packages/; \
-    apk add --allow-untrusted ~builder/packages/testing/**/varnish-modules-0.22.0-r0.apk; \
+    apk add --no-cache envsubst nginx; \
+    apk add varnish --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main; \
+    apk add varnish-modules --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing; \
     \
     rm /etc/nginx/http.d/default.conf; \
     nginx -t -c /etc/nginx/nginx.conf; \
     \
-    apk del --no-network build; \
-    rm -rf ~builder /packages /aports /etc/sudoers.d/builder; \
-    deluser --remove-home builder; \
     chown varnish /var/lib/varnish;
 
 ENTRYPOINT ["./docker-entrypoint.sh"]


### PR DESCRIPTION
### Issue
- Docker build is failing because after alpine upgraded its packages the build dependencies were locking it to the same version.

Ref: https://hub.docker.com/repository/registry-1.docker.io/platforme/proxy_cached/builds/546a26d9-93a9-4609-8e45-4ffb7ea87fe8

### Dependencies
- None

### Decisions
- Use `sed` to replace `~=` with `>=` to allow higher versions

### Screenshots
- None
